### PR TITLE
design: 판매자 정보 입력 페이지 UI 수정사항 반영

### DIFF
--- a/src/components/SellerDashboard/SellerInfo/CardComponents.tsx
+++ b/src/components/SellerDashboard/SellerInfo/CardComponents.tsx
@@ -8,7 +8,10 @@ import {
     Rating,
     Card,
     CardContent,
+    Chip,
+    Stack,
 } from "@mui/material";
+import { AccessTime as TimeIcon } from "@mui/icons-material";
 import { BRAND_COLORS } from "./constants";
 import { ProgressCircle } from "./BasicComponents";
 
@@ -17,12 +20,26 @@ interface ProfilePreviewCardProps {
     workshopName?: string;
     rating?: number;
     avatarEmoji?: string;
+    profileImage?: string | null;
+    tags?: string[];
+    operatingHours?: {
+        start: string;
+        end: string;
+        holidayInfo: string;
+    };
 }
 
 export const ProfilePreviewCard: React.FC<ProfilePreviewCardProps> = ({
                                                                           workshopName = "달콤한 우리집 간식공방",
                                                                           rating = 4.5,
-                                                                          avatarEmoji = "🐾"
+                                                                          avatarEmoji = "🐾",
+                                                                          profileImage = null,
+                                                                          tags = ["수제간식", "무첨가", "강아지전용"],
+                                                                          operatingHours = {
+                                                                              start: "09:00",
+                                                                              end: "18:00",
+                                                                              holidayInfo: "주말 및 공휴일 휴무"
+                                                                          }
                                                                       }) => (
     <Card sx={{
         backgroundColor: BRAND_COLORS.BACKGROUND_LIGHT,
@@ -45,25 +62,40 @@ export const ProfilePreviewCard: React.FC<ProfilePreviewCardProps> = ({
             >
                 현재 워크샵 프로필 요약과 고객에게 표시될 내용을 간략하게 확인해보세요.
             </Typography>
-            <Box display="flex" alignItems="center" gap={2}>
+
+            {/* 프로필 정보 */}
+            <Box display="flex" alignItems="flex-start" gap={2} mb={3}>
                 <Avatar sx={{
                     width: 96,
                     height: 96,
                     borderRadius: 2,
-                    backgroundColor: BRAND_COLORS.PRIMARY,
-                    fontSize: '2rem'
+                    backgroundColor: profileImage ? "transparent" : BRAND_COLORS.PRIMARY,
+                    fontSize: profileImage ? 0 : '2rem'
                 }}>
-                    {avatarEmoji}
+                    {profileImage ? (
+                        <img
+                            src={profileImage}
+                            alt="Profile"
+                            style={{
+                                width: '100%',
+                                height: '100%',
+                                objectFit: 'cover'
+                            }}
+                        />
+                    ) : (
+                        avatarEmoji
+                    )}
                 </Avatar>
                 <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography
                         variant="h6"
                         fontWeight="600"
                         color={BRAND_COLORS.TEXT_PRIMARY}
+                        mb={1}
                     >
                         {workshopName}
                     </Typography>
-                    <Box display="flex" alignItems="center" mt={1}>
+                    <Box display="flex" alignItems="center" mb={2}>
                         <Rating value={rating} precision={0.5} readOnly size="small" />
                         <Typography
                             variant="body2"
@@ -73,8 +105,46 @@ export const ProfilePreviewCard: React.FC<ProfilePreviewCardProps> = ({
                             ({rating}/5.0)
                         </Typography>
                     </Box>
+
+                    {/* 운영시간 */}
+                    <Box display="flex" alignItems="center" mb={2}>
+                        <TimeIcon sx={{ fontSize: 16, color: BRAND_COLORS.TEXT_SECONDARY, mr: 1 }} />
+                        <Typography variant="body2" color={BRAND_COLORS.TEXT_SECONDARY}>
+                            {operatingHours.start} - {operatingHours.end} ({operatingHours.holidayInfo})
+                        </Typography>
+                    </Box>
                 </Box>
             </Box>
+
+            {/* 태그 */}
+            {tags.length > 0 && (
+                <Box>
+                    <Typography
+                        variant="body2"
+                        fontWeight="500"
+                        color={BRAND_COLORS.TEXT_PRIMARY}
+                        mb={1}
+                    >
+                        워크샵 태그
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        {tags.map((tag, index) => (
+                            <Chip
+                                key={index}
+                                label={`#${tag}`}
+                                size="small"
+                                sx={{
+                                    backgroundColor: BRAND_COLORS.PRIMARY,
+                                    color: "white",
+                                    fontSize: "0.75rem",
+                                    height: 24,
+                                    mb: 1
+                                }}
+                            />
+                        ))}
+                    </Stack>
+                </Box>
+            )}
         </CardContent>
     </Card>
 );
@@ -118,6 +188,7 @@ export const CompletionCard: React.FC<CompletionCardProps> = ({
                 variant="caption"
                 color={BRAND_COLORS.TEXT_SECONDARY}
                 mt={2}
+                textAlign="center"
             >
                 완성도를 높여 더 많은 고객을 만나세요!
             </Typography>

--- a/src/components/SellerDashboard/SellerInfo/FormComponents.tsx
+++ b/src/components/SellerDashboard/SellerInfo/FormComponents.tsx
@@ -1,73 +1,390 @@
 // src/components/SellerDashboard/SellerInfo/FormComponents.tsx
 
-import React from "react";
+import React, { useState, useRef } from "react";
 import {
     Box,
     Typography,
     TextField,
     Stack,
+    Grid,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Chip,
+    Avatar,
+    IconButton,
+    Paper,
+    MenuItem,
+    Select,
+    FormControl,
+    InputLabel,
 } from "@mui/material";
+import {
+    Search as SearchIcon,
+    Add as AddIcon,
+    CameraAlt as CameraIcon,
+    Delete as DeleteIcon,
+} from "@mui/icons-material";
 import { BRAND_COLORS, PrimaryButton, SecondaryButton } from "./constants";
 import { FormField } from "./BasicComponents";
 
-// ==================== 기본 정보 폼 데이터 타입 ====================
+// ==================== 확장된 폼 데이터 타입 ====================
 export interface BasicInfoFormData {
     workshopName: string;
     representativeName: string;
     businessNumber: string;
-    businessAddress: string;
+    postalCode: string;
+    roadAddress: string;
+    detailAddress: string;
+    tags: string[];
+    operatingHours: {
+        start: string;
+        end: string;
+        breakTime?: string;
+        holidayInfo: string;
+    };
+    profileImage: string | null;
 }
 
-// ==================== 기본 정보 폼 ====================
-interface BasicInfoFormProps {
-    data: BasicInfoFormData;
-    onChange: (field: keyof BasicInfoFormData, value: string) => void;
-    onBusinessNumberVerify?: () => void;
+// ==================== 주소 검색 모달 ====================
+interface AddressSearchModalProps {
+    open: boolean;
+    onClose: () => void;
+    onSelect: (address: { postalCode: string; roadAddress: string }) => void;
 }
 
-export const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
-                                                                data,
-                                                                onChange,
-                                                                onBusinessNumberVerify
-                                                            }) => (
-    <Box>
-        <Typography
-            variant="h5"
-            fontWeight="600"
-            color={BRAND_COLORS.TEXT_PRIMARY}
-            mb={3}
-        >
-            기본 정보 설정
-        </Typography>
-        <Stack spacing={3}>
-            <FormField
-                label="워크샵 이름"
-                required
-                placeholder="예: 냥멍이네 수제간식 공방"
-                value={data.workshopName}
-                onChange={(e) => onChange('workshopName', e.target.value)}
-            />
-            <FormField
-                label="대표자명"
-                placeholder="홍길동"
-                value={data.representativeName}
-                onChange={(e) => onChange('representativeName', e.target.value)}
-            />
-            <Box>
-                <Typography
-                    variant="body2"
-                    fontWeight="500"
-                    color={BRAND_COLORS.TEXT_PRIMARY}
-                    mb={1}
-                >
-                    사업자 등록번호
+const AddressSearchModal: React.FC<AddressSearchModalProps> = ({
+                                                                   open,
+                                                                   onClose,
+                                                                   onSelect,
+                                                               }) => {
+    const [searchKeyword, setSearchKeyword] = useState("");
+    const [searchResults] = useState([
+        { postalCode: "06295", roadAddress: "서울특별시 강남구 테헤란로 123" },
+        { postalCode: "06296", roadAddress: "서울특별시 강남구 테헤란로 125" },
+        { postalCode: "06297", roadAddress: "서울특별시 강남구 테헤란로 127" },
+    ]);
+
+    const handleSelect = (address: { postalCode: string; roadAddress: string }) => {
+        onSelect(address);
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+            <DialogTitle>
+                <Typography variant="h6" fontWeight="600">
+                    주소 검색
                 </Typography>
-                <Box display="flex" gap={1}>
+            </DialogTitle>
+            <DialogContent>
+                <Box sx={{ mb: 3 }}>
+                    <Box display="flex" gap={1}>
+                        <TextField
+                            fullWidth
+                            placeholder="도로명, 건물명, 지번을 입력하세요"
+                            value={searchKeyword}
+                            onChange={(e) => setSearchKeyword(e.target.value)}
+                            sx={{
+                                "& .MuiOutlinedInput-root": {
+                                    backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                    borderRadius: 2,
+                                }
+                            }}
+                        />
+                        <PrimaryButton
+                            startIcon={<SearchIcon />}
+                            sx={{ minWidth: 100 }}
+                        >
+                            검색
+                        </PrimaryButton>
+                    </Box>
+                </Box>
+
+                <Stack spacing={1} sx={{ maxHeight: 300, overflow: "auto" }}>
+                    {searchResults.map((result, index) => (
+                        <Paper
+                            key={index}
+                            sx={{
+                                p: 2,
+                                cursor: "pointer",
+                                border: `1px solid ${BRAND_COLORS.BORDER}`,
+                                "&:hover": {
+                                    backgroundColor: BRAND_COLORS.BACKGROUND_LIGHT,
+                                    borderColor: BRAND_COLORS.PRIMARY,
+                                }
+                            }}
+                            onClick={() => handleSelect(result)}
+                        >
+                            <Typography variant="body2" fontWeight="500">
+                                [{result.postalCode}] {result.roadAddress}
+                            </Typography>
+                        </Paper>
+                    ))}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <SecondaryButton onClick={onClose}>
+                    취소
+                </SecondaryButton>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+// ==================== 태그 입력 컴포넌트 ====================
+interface TagInputProps {
+    tags: string[];
+    onChange: (tags: string[]) => void;
+}
+
+const TagInput: React.FC<TagInputProps> = ({ tags, onChange }) => {
+    const [inputValue, setInputValue] = useState("");
+
+    const handleAddTag = () => {
+        const trimmedValue = inputValue.trim();
+        if (trimmedValue && !tags.includes(trimmedValue)) {
+            onChange([...tags, trimmedValue]);
+            setInputValue("");
+        }
+    };
+
+    const handleRemoveTag = (tagToRemove: string) => {
+        onChange(tags.filter(tag => tag !== tagToRemove));
+    };
+
+    const handleKeyPress = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            handleAddTag();
+        }
+    };
+
+    return (
+        <Box>
+            <Typography
+                variant="body2"
+                fontWeight="500"
+                color={BRAND_COLORS.TEXT_PRIMARY}
+                mb={1}
+            >
+                워크샵 태그
+            </Typography>
+            <Box display="flex" gap={1} mb={2}>
+                <TextField
+                    fullWidth
+                    placeholder="태그를 입력하세요 (예: 수제간식, 무첨가, 강아지전용)"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onKeyPress={handleKeyPress}
+                    sx={{
+                        "& .MuiOutlinedInput-root": {
+                            backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                            borderRadius: 2,
+                            "&.Mui-focused fieldset": { borderColor: BRAND_COLORS.PRIMARY }
+                        }
+                    }}
+                />
+                <PrimaryButton
+                    onClick={handleAddTag}
+                    startIcon={<AddIcon />}
+                    sx={{ minWidth: 100 }}
+                >
+                    추가
+                </PrimaryButton>
+            </Box>
+            <Box display="flex" flexWrap="wrap" gap={1}>
+                {tags.map((tag, index) => (
+                    <Chip
+                        key={index}
+                        label={`#${tag}`}
+                        onDelete={() => handleRemoveTag(tag)}
+                        sx={{
+                            backgroundColor: BRAND_COLORS.PRIMARY,
+                            color: "white",
+                            "& .MuiChip-deleteIcon": {
+                                color: "white",
+                                "&:hover": {
+                                    color: BRAND_COLORS.BACKGROUND_LIGHT,
+                                }
+                            }
+                        }}
+                    />
+                ))}
+            </Box>
+        </Box>
+    );
+};
+
+// ==================== 프로필 이미지 업로드 ====================
+interface ProfileImageUploadProps {
+    currentImage: string | null;
+    onChange: (image: string | null) => void;
+}
+
+const ProfileImageUpload: React.FC<ProfileImageUploadProps> = ({
+                                                                   currentImage,
+                                                                   onChange,
+                                                               }) => {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleImageClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                onChange(e.target?.result as string);
+            };
+            reader.readAsDataURL(file);
+        }
+    };
+
+    const handleRemoveImage = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onChange(null);
+    };
+
+    return (
+        <Box>
+            <Typography
+                variant="body2"
+                fontWeight="500"
+                color={BRAND_COLORS.TEXT_PRIMARY}
+                mb={1}
+            >
+                프로필 이미지
+            </Typography>
+            <Box
+                sx={{
+                    position: "relative",
+                    width: 120,
+                    height: 120,
+                    borderRadius: 3,
+                    border: `2px dashed ${BRAND_COLORS.BORDER}`,
+                    backgroundColor: BRAND_COLORS.BACKGROUND_LIGHT,
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    overflow: "hidden",
+                    "&:hover": {
+                        borderColor: BRAND_COLORS.PRIMARY,
+                        backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                    }
+                }}
+                onClick={handleImageClick}
+            >
+                {currentImage ? (
+                    <>
+                        <img
+                            src={currentImage}
+                            alt="Profile"
+                            style={{
+                                width: "100%",
+                                height: "100%",
+                                objectFit: "cover",
+                            }}
+                        />
+                        <IconButton
+                            sx={{
+                                position: "absolute",
+                                top: 4,
+                                right: 4,
+                                backgroundColor: "rgba(0,0,0,0.5)",
+                                color: "white",
+                                "&:hover": {
+                                    backgroundColor: "rgba(0,0,0,0.7)",
+                                }
+                            }}
+                            size="small"
+                            onClick={handleRemoveImage}
+                        >
+                            <DeleteIcon fontSize="small" />
+                        </IconButton>
+                    </>
+                ) : (
+                    <Box textAlign="center">
+                        <CameraIcon
+                            sx={{
+                                fontSize: 32,
+                                color: BRAND_COLORS.TEXT_SECONDARY,
+                                mb: 1
+                            }}
+                        />
+                        <Typography
+                            variant="caption"
+                            color={BRAND_COLORS.TEXT_SECONDARY}
+                            display="block"
+                        >
+                            이미지 업로드
+                        </Typography>
+                    </Box>
+                )}
+            </Box>
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                style={{ display: "none" }}
+            />
+            <Typography
+                variant="caption"
+                color={BRAND_COLORS.TEXT_SECONDARY}
+                mt={1}
+                display="block"
+            >
+                권장 크기: 400x400px, 최대 5MB
+            </Typography>
+        </Box>
+    );
+};
+
+// ==================== 운영시간 입력 ====================
+interface OperatingHoursProps {
+    hours: {
+        start: string;
+        end: string;
+        breakTime?: string;
+        holidayInfo: string;
+    };
+    onChange: (hours: {
+        start: string;
+        end: string;
+        breakTime?: string;
+        holidayInfo: string;
+    }) => void;
+}
+
+const OperatingHours: React.FC<OperatingHoursProps> = ({ hours, onChange }) => {
+    return (
+        <Box>
+            <Typography
+                variant="body2"
+                fontWeight="500"
+                color={BRAND_COLORS.TEXT_PRIMARY}
+                mb={1}
+            >
+                운영시간
+                <Typography component="span" color="error" ml={0.5}>*</Typography>
+            </Typography>
+            <Grid container spacing={1.5} sx={{ alignItems: 'flex-end' }}>
+                <Grid item xs={3} sm={3}>
                     <TextField
                         fullWidth
-                        placeholder="123-45-67890"
-                        value={data.businessNumber}
-                        onChange={(e) => onChange('businessNumber', e.target.value)}
+                        label="시작시간"
+                        placeholder="09:00"
+                        value={hours.start}
+                        onChange={(e) => onChange({ ...hours, start: e.target.value })}
+                        inputProps={{
+                            pattern: "[0-9]{2}:[0-9]{2}",
+                            placeholder: "HH:MM"
+                        }}
                         sx={{
                             "& .MuiOutlinedInput-root": {
                                 backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
@@ -76,23 +393,230 @@ export const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
                             }
                         }}
                     />
-                    <SecondaryButton
-                        onClick={onBusinessNumberVerify}
-                        sx={{ minWidth: 120, whiteSpace: "nowrap" }}
+                </Grid>
+                <Grid item xs={3} sm={3}>
+                    <TextField
+                        fullWidth
+                        label="종료시간"
+                        placeholder="18:00"
+                        value={hours.end}
+                        onChange={(e) => onChange({ ...hours, end: e.target.value })}
+                        inputProps={{
+                            pattern: "[0-9]{2}:[0-9]{2}",
+                            placeholder: "HH:MM"
+                        }}
+                        sx={{
+                            "& .MuiOutlinedInput-root": {
+                                backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                borderRadius: 2,
+                                "&.Mui-focused fieldset": { borderColor: BRAND_COLORS.PRIMARY }
+                            }
+                        }}
+                    />
+                </Grid>
+                <Grid item xs={6} sm={6}>
+                    <TextField
+                        fullWidth
+                        label="휴무정보"
+                        placeholder="예: 주말 및 공휴일 휴무"
+                        value={hours.holidayInfo}
+                        onChange={(e) => onChange({ ...hours, holidayInfo: e.target.value })}
+                        sx={{
+                            "& .MuiOutlinedInput-root": {
+                                backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                borderRadius: 2,
+                                "&.Mui-focused fieldset": { borderColor: BRAND_COLORS.PRIMARY }
+                            }
+                        }}
+                    />
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};
+
+// ==================== 향상된 기본 정보 폼 ====================
+interface BasicInfoFormProps {
+    data: BasicInfoFormData;
+    onChange: (field: keyof BasicInfoFormData, value: any) => void;
+    onBusinessNumberVerify?: () => void;
+}
+
+export const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
+                                                                data,
+                                                                onChange,
+                                                                onBusinessNumberVerify
+                                                            }) => {
+    const [addressModalOpen, setAddressModalOpen] = useState(false);
+
+    const handleAddressSelect = (address: { postalCode: string; roadAddress: string }) => {
+        onChange('postalCode', address.postalCode);
+        onChange('roadAddress', address.roadAddress);
+    };
+
+    return (
+        <Box>
+            <Stack spacing={4}>
+                {/* 프로필 이미지 */}
+                <ProfileImageUpload
+                    currentImage={data.profileImage}
+                    onChange={(image) => onChange('profileImage', image)}
+                />
+
+                {/* 워크샵 이름 - 저장하기 버튼까지의 너비로 확장 */}
+                <FormField
+                    label="워크샵 이름"
+                    required
+                    placeholder="예: 냥멍이네 수제간식 공방"
+                    value={data.workshopName}
+                    onChange={(e) => onChange('workshopName', e.target.value)}
+                />
+
+                {/* 대표자명과 사업자 등록번호 - 전체 너비 꽉 채움 */}
+                <Grid container spacing={3}>
+                    <Grid item xs={12} md={3}>
+                        <FormField
+                            label="대표자명"
+                            required
+                            placeholder="홍길동"
+                            value={data.representativeName}
+                            onChange={(e) => onChange('representativeName', e.target.value)}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <Box>
+                            <Typography
+                                variant="body2"
+                                fontWeight="500"
+                                color={BRAND_COLORS.TEXT_PRIMARY}
+                                mb={1}
+                            >
+                                사업자 등록번호
+                                <Typography component="span" color="error" ml={0.5}>*</Typography>
+                            </Typography>
+                            <TextField
+                                fullWidth
+                                placeholder="123-45-67890"
+                                value={data.businessNumber}
+                                onChange={(e) => onChange('businessNumber', e.target.value)}
+                                sx={{
+                                    "& .MuiOutlinedInput-root": {
+                                        backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                        borderRadius: 2,
+                                        "&.Mui-focused fieldset": { borderColor: BRAND_COLORS.PRIMARY }
+                                    }
+                                }}
+                            />
+                        </Box>
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <Box>
+                            <Typography
+                                variant="body2"
+                                fontWeight="500"
+                                color="transparent"
+                                mb={1}
+                                sx={{ height: '20px' }}
+                            >
+                                {/* 버튼 정렬을 위한 투명 레이블 - 높이 고정 */}
+                                사업자 등록번호
+                            </Typography>
+                            <SecondaryButton
+                                fullWidth
+                                onClick={onBusinessNumberVerify}
+                                sx={{ height: 56 }}
+                            >
+                                인증요청
+                            </SecondaryButton>
+                        </Box>
+                    </Grid>
+                </Grid>
+
+                {/* 주소 입력 - 저장하기 버튼까지의 너비로 확장 */}
+                <Box>
+                    <Typography
+                        variant="body2"
+                        fontWeight="500"
+                        color={BRAND_COLORS.TEXT_PRIMARY}
+                        mb={1}
                     >
-                        인증요청
-                    </SecondaryButton>
+                        사업자 주소
+                        <Typography component="span" color="error" ml={0.5}>*</Typography>
+                    </Typography>
+                    <Stack spacing={2}>
+                        <Box display="flex" gap={1}>
+                            <TextField
+                                placeholder="우편번호"
+                                value={data.postalCode}
+                                onChange={(e) => onChange('postalCode', e.target.value)}
+                                sx={{
+                                    width: 120,
+                                    "& .MuiOutlinedInput-root": {
+                                        backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                        borderRadius: 2,
+                                    }
+                                }}
+                                InputProps={{ readOnly: true }}
+                            />
+                            <PrimaryButton
+                                startIcon={<SearchIcon />}
+                                onClick={() => setAddressModalOpen(true)}
+                                sx={{ minWidth: 100 }}
+                            >
+                                주소검색
+                            </PrimaryButton>
+                        </Box>
+                        <TextField
+                            fullWidth
+                            placeholder="도로명 주소"
+                            value={data.roadAddress}
+                            onChange={(e) => onChange('roadAddress', e.target.value)}
+                            sx={{
+                                "& .MuiOutlinedInput-root": {
+                                    backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                    borderRadius: 2,
+                                }
+                            }}
+                            InputProps={{ readOnly: true }}
+                        />
+                        <TextField
+                            fullWidth
+                            placeholder="상세 주소를 입력하세요"
+                            value={data.detailAddress}
+                            onChange={(e) => onChange('detailAddress', e.target.value)}
+                            sx={{
+                                "& .MuiOutlinedInput-root": {
+                                    backgroundColor: BRAND_COLORS.BACKGROUND_INPUT,
+                                    borderRadius: 2,
+                                    "&.Mui-focused fieldset": { borderColor: BRAND_COLORS.PRIMARY }
+                                }
+                            }}
+                        />
+                    </Stack>
                 </Box>
-            </Box>
-            <FormField
-                label="사업자 주소"
-                placeholder="서울특별시 강남구 테헤란로 123"
-                value={data.businessAddress}
-                onChange={(e) => onChange('businessAddress', e.target.value)}
+
+                {/* 태그 입력 - 저장하기 버튼까지의 너비로 확장 */}
+                <TagInput
+                    tags={data.tags}
+                    onChange={(tags) => onChange('tags', tags)}
+                />
+
+                {/* 운영시간 */}
+                <OperatingHours
+                    hours={data.operatingHours}
+                    onChange={(hours) => onChange('operatingHours', hours)}
+                />
+            </Stack>
+
+            {/* 주소 검색 모달 */}
+            <AddressSearchModal
+                open={addressModalOpen}
+                onClose={() => setAddressModalOpen(false)}
+                onSelect={handleAddressSelect}
             />
-        </Stack>
-    </Box>
-);
+        </Box>
+    );
+};
 
 // ==================== 폼 액션 버튼 ====================
 interface FormActionsProps {

--- a/src/components/SellerDashboard/SellerInfo/index.ts
+++ b/src/components/SellerDashboard/SellerInfo/index.ts
@@ -1,4 +1,4 @@
-// src/components/SellerDashboard/SellerInfo/// src/components/SellerDashboard/SellerInfo/index.ts
+// src/components/SellerDashboard/SellerInfo/index.ts
 
 // 컴포넌트 export
 export { BRAND_COLORS, PrimaryButton, SecondaryButton } from "./constants";

--- a/src/components/SellerDashboard/SellerInfo/useSellerInfo.ts
+++ b/src/components/SellerDashboard/SellerInfo/useSellerInfo.ts
@@ -6,7 +6,17 @@ export interface SellerInfoData {
     workshopName: string;
     representativeName: string;
     businessNumber: string;
-    businessAddress: string;
+    postalCode: string;
+    roadAddress: string;
+    detailAddress: string;
+    tags: string[];
+    operatingHours: {
+        start: string;
+        end: string;
+        breakTime?: string;
+        holidayInfo: string;
+    };
+    profileImage: string | null;
     completionRate: number;
     rating: number;
     avatarEmoji: string;
@@ -16,7 +26,16 @@ const initialData: SellerInfoData = {
     workshopName: "",
     representativeName: "",
     businessNumber: "",
-    businessAddress: "",
+    postalCode: "",
+    roadAddress: "",
+    detailAddress: "",
+    tags: [],
+    operatingHours: {
+        start: "09:00",
+        end: "18:00",
+        holidayInfo: "주말 및 공휴일 휴무",
+    },
+    profileImage: null,
     completionRate: 75,
     rating: 4.5,
     avatarEmoji: "🐾",
@@ -27,25 +46,51 @@ export const useSellerInfo = () => {
     const [isLoading, setIsLoading] = useState(false);
     const [activeSection, setActiveSection] = useState("basic-info");
 
-    const updateField = useCallback((field: keyof SellerInfoData, value: string | number) => {
+    const updateField = useCallback((field: keyof SellerInfoData, value: any) => {
         setData(prev => ({
             ...prev,
             [field]: value
         }));
     }, []);
 
+    // 완성도 계산 함수
+    const calculateCompletionRate = useCallback((data: SellerInfoData) => {
+        const fields = [
+            data.workshopName,
+            data.representativeName,
+            data.businessNumber,
+            data.roadAddress,
+            data.detailAddress,
+            data.operatingHours.start,
+            data.operatingHours.end,
+            data.operatingHours.holidayInfo,
+        ];
+
+        const imageBonus = data.profileImage ? 1 : 0;
+        const tagBonus = data.tags.length > 0 ? 1 : 0;
+
+        const filledFields = fields.filter(field => field && field.trim() !== "").length;
+        const totalFields = fields.length + 2; // 이미지와 태그 포함
+
+        return Math.round(((filledFields + imageBonus + tagBonus) / totalFields) * 100);
+    }, []);
+
     const handleSave = useCallback(async () => {
         setIsLoading(true);
         try {
-            // TODO: API 호출
+            // 완성도 업데이트
+            const newCompletionRate = calculateCompletionRate(data);
+            setData(prev => ({ ...prev, completionRate: newCompletionRate }));
+
             console.log("저장하기:", data);
+            // TODO: API 호출
             // await saveSellerInfo(data);
         } catch (error) {
             console.error("저장 실패:", error);
         } finally {
             setIsLoading(false);
         }
-    }, [data]);
+    }, [data, calculateCompletionRate]);
 
     const handleCancel = useCallback(() => {
         setData(initialData);
@@ -61,6 +106,10 @@ export const useSellerInfo = () => {
         try {
             console.log("사업자 등록번호 인증:", data.businessNumber);
             // TODO: 실제 API 호출
+            // const result = await verifyBusinessNumber(data.businessNumber);
+            // if (result.success) {
+            //     alert("인증이 완료되었습니다.");
+            // }
         } catch (error) {
             console.error("인증 실패:", error);
         } finally {
@@ -71,6 +120,7 @@ export const useSellerInfo = () => {
     const handleCustomerViewClick = useCallback(() => {
         console.log("고객 화면으로 이동");
         // TODO: 고객 화면으로 이동 로직
+        // 예시: navigate('/seller/1');
     }, []);
 
     return {

--- a/src/pages/SellerDashboardPage/SellerInfoPage.tsx
+++ b/src/pages/SellerDashboardPage/SellerInfoPage.tsx
@@ -25,8 +25,8 @@ const SellerInfoPage: React.FC = () => {
 
     return (
         <Box sx={{ p: { xs: 2, md: 4 } }}>
-            {/* 페이지 제목 */}
-            <Box sx={{ mb: 4 }}>
+            {/* 페이지 제목 - Paper 밖으로 분리하여 가독성 향상 */}
+            <Box sx={{ mb: 4, ml: { xs: 2, sm: 3, md: 4 } }}>
                 <Typography
                     variant="h3"
                     sx={{
@@ -50,53 +50,74 @@ const SellerInfoPage: React.FC = () => {
                 </Typography>
             </Box>
 
-            <Grid container spacing={{ xs: 2, sm: 3 }}>
-                <Grid size={{ xs: 12, md: 9 }}>
-                    <Paper
-                        sx={{
-                            p: { xs: 2, sm: 3, md: 4 },
-                            borderRadius: 3,
-                            border: `1px solid ${BRAND_COLORS.BORDER}`,
+            {/* 메인 콘텐츠 */}
+            <Paper
+                sx={{
+                    p: { xs: 2, sm: 3, md: 4 },
+                    borderRadius: 3,
+                    border: `1px solid ${BRAND_COLORS.BORDER}`,
+                    mx: { xs: 2, sm: 3, md: 4 },
+                }}
+            >
+                <Box sx={{ maxWidth: { xs: "100%", sm: "50%" }, minWidth: { sm: "600px" } }}>
+                    <PageHeader
+                        title="기본 정보 설정"
+                        onCustomerViewClick={handleCustomerViewClick}
+                    />
+                </Box>
+
+                {/* 카드 섹션 - 반응형 너비 조정 */}
+                <Box sx={{ maxWidth: { xs: "100%", sm: "50%" }, minWidth: { sm: "600px" } }}>
+                    <Box sx={{
+                        display: "flex",
+                        flexDirection: { xs: "column", sm: "row" },
+                        gap: 2,
+                        mb: 4
+                    }}>
+                        {/* 프로필 미리보기 카드 */}
+                        <Box sx={{ flex: { sm: 2 }, width: "100%" }}>
+                            <ProfilePreviewCard
+                                workshopName={data.workshopName || "달콤한 우리집 간식공방"}
+                                rating={data.rating}
+                                avatarEmoji={data.avatarEmoji}
+                                profileImage={data.profileImage}
+                                tags={data.tags}
+                                operatingHours={data.operatingHours}
+                            />
+                        </Box>
+
+                        {/* 완성도 카드 */}
+                        <Box sx={{ flex: { sm: 1 }, width: "100%", minWidth: { sm: 200 } }}>
+                            <CompletionCard completionRate={data.completionRate} />
+                        </Box>
+                    </Box>
+                </Box>
+
+                {/* 폼 섹션 - 반응형 너비 조정 */}
+                <Box sx={{ maxWidth: { xs: "100%", sm: "50%" }, minWidth: { sm: "600px" } }}>
+                    <BasicInfoForm
+                        data={{
+                            workshopName: data.workshopName,
+                            representativeName: data.representativeName,
+                            businessNumber: data.businessNumber,
+                            postalCode: data.postalCode,
+                            roadAddress: data.roadAddress,
+                            detailAddress: data.detailAddress,
+                            tags: data.tags,
+                            operatingHours: data.operatingHours,
+                            profileImage: data.profileImage,
                         }}
-                    >
-                        <PageHeader
-                            title="내 페이지"
-                            onCustomerViewClick={handleCustomerViewClick}
-                        />
+                        onChange={updateField}
+                        onBusinessNumberVerify={handleBusinessNumberVerify}
+                    />
 
-                        <Grid container spacing={3} sx={{ mb: 4 }}>
-                            <Grid size={{ xs: 12, md: 8 }}>
-                                <ProfilePreviewCard
-                                    workshopName={data.workshopName || "달콤한 우리집 간식공방"}
-                                    rating={data.rating}
-                                    avatarEmoji={data.avatarEmoji}
-                                />
-                            </Grid>
-
-                            <Grid size={{ xs: 12, md: 4 }}>
-                                <CompletionCard completionRate={data.completionRate} />
-                            </Grid>
-                        </Grid>
-
-                        <BasicInfoForm
-                            data={{
-                                workshopName: data.workshopName,
-                                representativeName: data.representativeName,
-                                businessNumber: data.businessNumber,
-                                businessAddress: data.businessAddress,
-                            }}
-                            onChange={updateField}
-                            onBusinessNumberVerify={handleBusinessNumberVerify}
-                        />
-
-                        <FormActions
-                            onSave={handleSave}
-                            onCancel={handleCancel}
-                            isLoading={isLoading}
-                        />
-                    </Paper>
-                </Grid>
-            </Grid>
+                    <FormActions
+                        onSave={handleSave}
+                        onCancel={handleCancel}
+                        isLoading={isLoading}
+                    />
+                </Box>
+            </Paper>
         </Box>
     );
 };


### PR DESCRIPTION
1. 주소 입력을 주소 불러오기 UI로 변경 (API)
    - 우편번호
    - 도로명 주소
    - 상세 주소
2. 태그 입력 UI 추가
3. 운영시간 항목 추가
4. 기본 정보 설정 제일 위로 (텍스트 수정 ‘내 페이지’ → ‘기본 정보 설정’)
5. 워크샵 프로필 이미지 → 여기서 수정 (이미지 업로드, 수정, 삭제)
6. 대표자명 / 사업자 등록 번호 박스 사이즈 줄여서 같은 행으로 ( ex) 40% )
7. 워크샵 이름만 별표 X (박스 사이즈 마찬가지로 줄여야 함)